### PR TITLE
Fix wrong log level in new ewts msg

### DIFF
--- a/src/topmodel.c
+++ b/src/topmodel.c
@@ -579,7 +579,7 @@ extern int tread(
 
     /* Guard against divide-by-zero if file is malformed */
     if (tarea == 0.0) {
-        Log(ERROR, "tread(): Sum of dist_area_lnaotb is zero; cannot normalize.\n");
+        Log(SEVERE, "tread(): Sum of dist_area_lnaotb is zero; cannot normalize.\n");
         return -1;
     }
 


### PR DESCRIPTION
## Changes

- Changed ERROR log level, which doesn't exist, to SEVERE in topmodel.c

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

