### PR TITLE
Adapt serialization to revised protocol

### DIFF
--- a/src/bmi_serialization.cpp
+++ b/src/bmi_serialization.cpp
@@ -89,7 +89,7 @@ const int serialize_topmodel(Bmi* bmi) {
     try {
         archive << serializer;
     } catch (const std::exception& e) {
-        Log(LogLevel::SEVERE, "Serializing Topmodel encounterd an error: %s", e.what());
+        Log(LogLevel::SEVERE, "Serializing Topmodel encountered an error: %s", e.what());
         return BMI_FAILURE;
     }
     // copy serialized data into topmodel data


### PR DESCRIPTION
The earlier BMI state saving protocol was not going to be tenable on Fortran due to `intent(in)` dummy arguments. This revision simplifies the protocol such that `SetValue` is used for mutating actions, and `GetValue/GetValuePtr` are used for queries.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: