### PR TITLE
Having Consistent RainMelt Value for all Runoff Models

### DIFF
--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -810,8 +810,8 @@ static int Get_value_ptr(Bmi *self, const char *name, void **dest) {
     if (strcmp(name, "atmosphere_water__liquid_equivalent_precipitation_rate_out") == 0) {
         topmodel_model *topmodel;
         topmodel = (topmodel_model *)self->data;
-        *dest    = (void *)&topmodel->p;
-        //*dest = (void*)&topmodel->rain[1]; Note: these are the same ==, either would work
+        //*dest    = (void *)&topmodel->p;//Note: these are the same ==, either would work
+        *dest = (void*)&topmodel->rain[1]; 
         return BMI_SUCCESS;
         // ep
     }


### PR DESCRIPTION
https://jira.nextgenwaterprediction.com/browse/NGWPC-9963

I found during testing the atmosphere_water__liquid_equivalent_precipitation_rate_out value not matching the input (QINSUR in my case). So updated the implementation to match it.

Updated the Get Value of : atmosphere_water__liquid_equivalent_precipitation_rate_out

## Testing

https://confluence.nextgenwaterprediction.com/spaces/NGWPC/pages/90177659/RR+models+Consistent+rain+melt+Output#RRmodelsConsistentrain+meltOutput-TOPMODEL
