### PR TITLE
Fix for incorrectly identified log messages

### DIFF
--- a/include/logger.h
+++ b/include/logger.h
@@ -1,7 +1,13 @@
 #ifndef TOPMODEL_LOGGER_H
 #define TOPMODEL_LOGGER_H
+
 #include "ewts/module_constants.h"
-#define EWTS_ID EWTS_ID_TOPMODEL
 #include "ewts/logger.h"
 #include "ewts/log_levels.h"
+
+#define Log(level, ...) EwtsLogModule(EWTS_ID_TOPMODEL, (level), __VA_ARGS__)
+#define LOG(level, ...) EwtsLogModule(EWTS_ID_TOPMODEL, (level), __VA_ARGS__)
+#define GetLogLevel() EwtsGetLogLevelModule(EWTS_ID_TOPMODEL)
+#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(EWTS_ID_TOPMODEL)
+
 #endif /* TOPMODEL_LOGGER_H */


### PR DESCRIPTION
Remove using generic EWTS_ID and define LOG in submodule instead of relying on generic definition in ewts library which was causing log messages to be incorrectly identified in the logs.