### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/include/logger.h
+++ b/include/logger.h
@@ -1,13 +1,119 @@
 #ifndef TOPMODEL_LOGGER_H
 #define TOPMODEL_LOGGER_H
 
+#ifdef TOPMODEL_USE_EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Using EWTS
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
 #include "ewts/module_constants.h"
 #include "ewts/logger.h"
 #include "ewts/log_levels.h"
 
-#define Log(level, ...) EwtsLogModule(EWTS_ID_TOPMODEL, (level), __VA_ARGS__)
-#define LOG(level, ...) EwtsLogModule(EWTS_ID_TOPMODEL, (level), __VA_ARGS__)
-#define GetLogLevel() EwtsGetLogLevelModule(EWTS_ID_TOPMODEL)
-#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(EWTS_ID_TOPMODEL)
+#define TOPMODEL_MODULE_ID EWTS_ID_TOPMODEL
 
+#define Log(level, ...) EwtsLogModule(TOPMODEL_MODULE_ID, (level), __VA_ARGS__)
+#define LOG(level, ...) EwtsLogModule(TOPMODEL_MODULE_ID, (level), __VA_ARGS__)
+#define GetLogLevel() EwtsGetLogLevelModule(TOPMODEL_MODULE_ID)
+#define IsLoggingEnabled() EwtsIsLoggingEnabledModule(TOPMODEL_MODULE_ID)
+
+#else
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+// Log messages written to STDOUT
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define TOPMODEL_MODULE_ID "TOPMODEL"
+typedef enum {
+    NOTSET  = 0,
+    DEBUG   = 10,
+    PERFORM = 15,
+    INFO    = 20,
+    WARNING = 30,
+    SEVERE  = 40,
+    FATAL   = 50
+} LogLevel;
+
+#define TOPMODEL_FALLBACK_LOGGING_ENABLED   1
+#define TOPMODEL_FALLBACK_LOG_LEVEL         INFO
+
+static inline bool IsLoggingEnabled(void) {
+    return TOPMODEL_FALLBACK_LOGGING_ENABLED;
+}
+
+static inline LogLevel GetLogLevel(void) {
+    return TOPMODEL_FALLBACK_LOG_LEVEL;
+}
+
+static inline const char* cfe_level_to_string(LogLevel level) {
+    switch (level) {
+        case DEBUG:   return "DEBUG";
+        case PERFORM: return "PERFORM";
+        case INFO:    return "INFO";
+        case WARNING: return "WARN";
+        case SEVERE:  return "ERROR";
+        case FATAL:   return "FATAL";
+        default:      return "LOG";
+    }
+}
+
+static inline void cfe_utc_timestamp(char* buffer, size_t size) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+
+    struct tm tm_utc;
+    gmtime_r(&tv.tv_sec, &tm_utc);
+
+    char base[32];
+    strftime(base, sizeof(base), "%Y-%m-%dT%H:%M:%S", &tm_utc);
+
+    snprintf(buffer, size, "%s.%03ldZ", base, tv.tv_usec / 1000);
+}
+
+static inline void cfe_strip_trailing_newlines(char* s) {
+    if (!s) return;
+
+    size_t len = strlen(s);
+    while (len > 0 && (s[len - 1] == '\n' || s[len - 1] == '\r')) {
+        s[--len] = '\0';
+    }
+}
+
+static inline void Log(LogLevel level, const char* fmt, ...) {
+    if (!fmt) return;
+    if (!IsLoggingEnabled()) return;
+    if (level < GetLogLevel()) return;
+
+    char message[4096];
+
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(message, sizeof(message), fmt, args);
+    va_end(args);
+
+    cfe_strip_trailing_newlines(message);
+
+    char timestamp[64];
+    cfe_utc_timestamp(timestamp, sizeof(timestamp));
+
+    char line[8192];
+    snprintf(line, sizeof(line), "%s %s %s %s\n",
+             timestamp,
+             TOPMODEL_MODULE_ID,
+             cfe_level_to_string(level),
+             message);
+
+    fputs(line, stdout);
+    fflush(stdout);
+}
+
+#define LOG(level, ...) Log((level), __VA_ARGS__)
+#endif
 #endif /* TOPMODEL_LOGGER_H */

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -420,11 +420,12 @@ static int Initialize(Bmi *self, const char *cfg_file) {
     topmodel_model *topmodel;
     topmodel = (topmodel_model *)self->data;
 
-    // Initialize the Error, Warning and Trapping System
-#ifdef USE_EWTS    
-    EwtsInit(EWTS_ID_TOPMODEL, true);
+#ifdef TOPMODEL_USE_EWTS
+    // Initialize the Error and Warning Trapping System
+    #pragma message("topmodel.bmi_topmodel.Initialize: TOPMODEL_USE_EWTS ON")
+    EwtsInit(TOPMODEL_MODULE_ID, true);
 #else
-    EwtsInit(EWTS_ID_TOPMODEL, false);
+    #pragma message("topmodel.bmi_topmodel.Initialize: TOPMODEL_USE_EWTS OFF")
 #endif    
     
     // Read and setup data from file

--- a/src/bmi_topmodel.c
+++ b/src/bmi_topmodel.c
@@ -421,7 +421,7 @@ static int Initialize(Bmi *self, const char *cfg_file) {
     topmodel = (topmodel_model *)self->data;
 
     // Initialize the Error, Warning and Trapping System
-#ifdef EWTS_HAVE_NGEN_BRIDGE    
+#ifdef USE_EWTS    
     EwtsInit(EWTS_ID_TOPMODEL, true);
 #else
     EwtsInit(EWTS_ID_TOPMODEL, false);


### PR DESCRIPTION
Exclude ewts when `TOPMODEL_USE_EWTS` preprocessor symbol is not defined. This symbol is set in the `ngen/extern/topmodel/CMakeFiles.tx`t based on the `USE_EWTS` symbol.

## Additions

- Added check for `TOPMODEL_USE_EWTS`. When defined, include the ewts library and initialize the ewts logger, otherwise fallback to stdout logging

## Removals

- Initializing the ewts logger when `USE_EWTS` is not defined. Log messages will be sent to stdout

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`